### PR TITLE
Copy system variables to #

### DIFF
--- a/wrappers/apl-dyalog
+++ b/wrappers/apl-dyalog
@@ -8,6 +8,7 @@ export MAXWS=128M WSPATH=$DYALOG/ws
 	cat .code.tio
 	echo
 	echo "'#'⎕NS⎕NL-⍳9"
+	echo "#.(⎕AVU⎕CT⎕DCT⎕DIV⎕FR⎕IO⎕LX⎕ML⎕PATH⎕PP⎕PW⎕RL⎕RTL⎕SM⎕TRAP⎕USING⎕WSID⎕WX)←⎕AVU⎕CT⎕DCT⎕DIV⎕FR⎕IO⎕LX⎕ML⎕PATH⎕PP⎕PW⎕RL⎕RTL⎕SM⎕TRAP⎕USING⎕WSID⎕WX"
 	echo :endnamespace
 } > ~/.bin.tio.dyalog
 


### PR DESCRIPTION
Often people want to set `⎕IO←0` or `⎕ML←3` or `⎕RL←⍬` etc. and get surprised when these changes are not reflected upon running. The problem is that we copy "everything" from the TIO namespace to #, but system variables are not part of "everything".