### PR TITLE
Compile Haskell code and expose compilation flags

### DIFF
--- a/usr/share/tio.run/languages.json
+++ b/usr/share/tio.run/languages.json
@@ -727,6 +727,9 @@
 				"encoding": "UTF-8",
 				"link": "https://www.haskell.org/",
 				"prettify": "hs",
+				"unmask": [
+					"cflags"
+				],
 				"update": "manual",
 				"tests": {
 					"helloWorld": {

--- a/wrappers/haskell
+++ b/wrappers/haskell
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 
-/usr/local/bin/runhaskell .code.tio "$@" < .input.tio
+ln -f .code.tio .code.tio.hs
+/usr/local/bin/ghc "${TIO_CFLAGS[@]}" -o .bin.tio .code.tio.hs
+./.bin.tio "$@" < .input.tio


### PR DESCRIPTION
Haskell is much faster when compiled rather than interpreted.