### PR TITLE
Add debug flag to Shnap

### DIFF
--- a/wrappers/shnap
+++ b/wrappers/shnap
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 ln -f .code.tio .code.tio.shnap
-java -jar /opt/shnap/Shnap-shadow.jar -arg=.code.tio -startScriptArgs "$@" < .input.tio
+java -jar /opt/shnap/Shnap-shadow.jar -arg=.code.tio -debug -startScriptArgs "$@" < .input.tio


### PR DESCRIPTION
The debug flag causes tracebacks to include more detail, and, if possible, point out the location of the problem in the source code. For small programs (like the ones in TIO), the flag is useful for finding errors, but in larger programs it can cause clutter...