### PR TITLE
Increase ⎕PW to max

### DIFF
--- a/wrappers/apl-dyalog
+++ b/wrappers/apl-dyalog
@@ -13,7 +13,7 @@ export MAXWS=128M WSPATH=$DYALOG/ws
 } > ~/.bin.tio.dyalog
 
 {
-	echo "⎕PW←9999"
+	echo "⎕PW←32767"
 	echo "{}2⎕FIX'file://$HOME/.bin.tio.dyalog'"
 	cat .input.tio
 	echo


### PR DESCRIPTION
To give sane wrapping for even larger output