### PR TITLE
added Curry (PAKCS)

### DIFF
--- a/usr/share/tio.run/languages.json
+++ b/usr/share/tio.run/languages.json
@@ -3368,6 +3368,31 @@
 		},
 		"update": "git"
 	},
+	"curry-pakcs": {
+		"categories": [
+			"practical"
+		],
+		"encoding": "UTF-8",
+		"link": "https://www.informatik.uni-kiel.de/~pakcs/",
+		"name": "Curry (PAKCS)",
+		"tests": {
+			"helloWorld": {
+				"request": [
+					{
+						"command": "F",
+						"payload": {
+							".code.tio": "main = putStr \"Hello, World!\""
+						}
+					}
+				],
+				"response": "Hello, World!"
+			}
+		},
+		"unmask": [
+			"cflags"
+		],
+		"update": "version"
+	},
 	"curry-sloth": {
 		"categories": [
 			"practical"

--- a/wrappers/curry-pakcs
+++ b/wrappers/curry-pakcs
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+ln -f .code.tio code.curry
+/opt/curry-pakcs/bin/pakcs "${TIO_CFLAGS[@]}" :load code.curry :save :quit >&2
+./code "$@" < .input.tio


### PR DESCRIPTION
Archive `pakcs-2.0.1-amd64-Linux.tar.gz` is not a binary distro, it is a source distro with one component compiled (frontend, written in Haskell). Everything else still needs to be compiled, hence `make`.

Setup script executes for 25 minutes on my machine. It appears to be hung sometimes, it compiles prolog files at those moments. SWI-Prolog is slow, so compilation is slow.

I tried to delete some directories other than `bin` after `make`, but `pakcs` errors out after this. So I kept everything, it is 78 MB.